### PR TITLE
Removed a space in the mailto: link in the nav

### DIFF
--- a/src/DotNetUserGroup.Website/Views/Shared/_navigation.cshtml
+++ b/src/DotNetUserGroup.Website/Views/Shared/_navigation.cshtml
@@ -32,7 +32,7 @@
                                       <i class="icon-eye-open"></i>News
                                   </a></li>
         <li class="divider"></li>
-        <li><a href="mailto: kelly@mindfulsanity.com">
+        <li><a href="mailto:kelly@mindfulsanity.com">
                 <i class="icon-envelope"></i>Contact
             </a></li>
         <li><a href="https://twitter.com/wpgnetug" target="_blank">


### PR DESCRIPTION
Hey!

This space was causing my browser to do nothing when clicking the Contact link.

The details about my environment are included ( CSV ): 

OS Type,OS Version,Browser Type,IP Address,Javascript Enabled,Cookies Enabled,Color Depth,Screen Resolution,Browser Window Size,Flash Version,User Agent
Apple,Mac OS X 10.8.4 Intel,Chrome,66.38.154.93,Yes,Yes,24,1920 x 1080,1915 x 986,11.8.800,"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36"
